### PR TITLE
Do not sync all changelog tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Know more about GoCD support for multiple databases [here](https://docs.gocd.org
 
 * As part of migrating data from a older GoCD `v20.4.0` (or below) to the GoCD `v20.5.0` database, users can convert/sync data from one database to another. This allows GoCD users to switch from any of the existing database to `H2`, `PostgreSQL` or `MySQL` database.
 
-### Note: This tool currently supports only migration of data from older GoCD database `v20.4.0` (or below) to the GoCD `v20.5.0` compatible database. Post migration, you cannot use this tool to sync data between different databases.
+* For databases which are already migrated and are GoCD `v20.5.0` compliant, this tool can be used to sync data to a new database post the initial migration to GoCD `v20.5.0`.
+E.g Sync data from a GoCD `v20.5.0` H2 database to a new PostgreSQL database. Verifyied to work till GoCD `v20.8.0`.
 
 ## Supported Databases
 
 * H2 (`1.3.xxx` and above)
 * PostgreSQL (`9.6` and above)
 * MySQL (`8.0`)
-
 
 ## Installation
 

--- a/src/main/java/com/thoughtworks/go/dbsync/DbSync.java
+++ b/src/main/java/com/thoughtworks/go/dbsync/DbSync.java
@@ -394,9 +394,10 @@ public class DbSync {
                     .fetch();
 
             for (Record1<String> record : result) {
-                String value = record.getValue(field);
-                if (!value.equalsIgnoreCase("CHANGELOG")) {
-                    tables.put(value, using(connection).fetchCount(table(value)));
+                String tableName = record.getValue(field);
+
+                if (!isChangeLogTable(tableName)) {
+                    tables.put(tableName, using(connection).fetchCount(table(tableName)));
                 }
             }
         });
@@ -404,4 +405,9 @@ public class DbSync {
         return tables;
     }
 
+    private static boolean isChangeLogTable(String tableName) {
+        return tableName.equalsIgnoreCase("CHANGELOG") ||
+                tableName.equalsIgnoreCase("DATABASECHANGELOG") ||
+                tableName.equalsIgnoreCase("DATABASECHANGELOGLOCK");
+    }
 }


### PR DESCRIPTION
* This is to support syncing data between databases which are already migrated
  and GoCD 20.5.0 compliant.